### PR TITLE
Add Rails models and database-level integrity constraints

### DIFF
--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,0 +1,3 @@
+class Answer < ApplicationRecord
+  belongs_to :question
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,2 @@
+class Category < ApplicationRecord
+end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,0 +1,3 @@
+class Question < ApplicationRecord
+  belongs_to :test
+end

--- a/app/models/test.rb
+++ b/app/models/test.rb
@@ -1,0 +1,4 @@
+class Test < ApplicationRecord
+  belongs_to :category
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,2 @@
+class User < ApplicationRecord
+end

--- a/db/migrate/20230416194231_create_tests.rb
+++ b/db/migrate/20230416194231_create_tests.rb
@@ -1,0 +1,13 @@
+class CreateTests < ActiveRecord::Migration[6.1]
+  def change
+    create_table :tests do |t|
+      t.string :name
+      t.integer :level
+      t.integer :time_limit
+      t.references :category, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230416194243_create_questions.rb
+++ b/db/migrate/20230416194243_create_questions.rb
@@ -1,0 +1,10 @@
+class CreateQuestions < ActiveRecord::Migration[6.1]
+  def change
+    create_table :questions do |t|
+      t.text :text
+      t.references :test, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230416194257_create_answers.rb
+++ b/db/migrate/20230416194257_create_answers.rb
@@ -1,0 +1,11 @@
+class CreateAnswers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :answers do |t|
+      t.text :text
+      t.references :question, null: false, foreign_key: true
+      t.boolean :correct
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230416194308_create_users.rb
+++ b/db/migrate/20230416194308_create_users.rb
@@ -1,0 +1,11 @@
+class CreateUsers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :users do |t|
+      t.string :name
+      t.string :email
+      t.string :password_digest
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230416194319_create_categories.rb
+++ b/db/migrate/20230416194319_create_categories.rb
@@ -1,0 +1,10 @@
+class CreateCategories < ActiveRecord::Migration[6.1]
+  def change
+    create_table :categories do |t|
+      t.string :name
+      t.text :description
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230416202039_add_default_level_to_tests.rb
+++ b/db/migrate/20230416202039_add_default_level_to_tests.rb
@@ -1,0 +1,5 @@
+class AddDefaultLevelToTests < ActiveRecord::Migration[6.1]
+  def change
+    change_column :tests, :level, :integer, :default => 0
+  end
+end

--- a/db/migrate/20230416202318_add_default_correct_to_answers.rb
+++ b/db/migrate/20230416202318_add_default_correct_to_answers.rb
@@ -1,0 +1,5 @@
+class AddDefaultCorrectToAnswers < ActiveRecord::Migration[6.1]
+  def change
+    change_column :answers, :correct, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,63 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2023_04_16_202318) do
+
+  create_table "answers", force: :cascade do |t|
+    t.text "text"
+    t.integer "question_id", null: false
+    t.boolean "correct", default: false, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["question_id"], name: "index_answers_on_question_id"
+  end
+
+  create_table "categories", force: :cascade do |t|
+    t.string "name"
+    t.text "description"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "questions", force: :cascade do |t|
+    t.text "text"
+    t.integer "test_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["test_id"], name: "index_questions_on_test_id"
+  end
+
+  create_table "tests", force: :cascade do |t|
+    t.string "name"
+    t.integer "level", default: 0
+    t.integer "time_limit"
+    t.integer "category_id", null: false
+    t.integer "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["category_id"], name: "index_tests_on_category_id"
+    t.index ["user_id"], name: "index_tests_on_user_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "name"
+    t.string "email"
+    t.string "password_digest"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  add_foreign_key "answers", "questions"
+  add_foreign_key "questions", "tests"
+  add_foreign_key "tests", "categories"
+  add_foreign_key "tests", "users"
+end

--- a/test/fixtures/answers.yml
+++ b/test/fixtures/answers.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  text: MyText
+  question: one
+  correct: false
+
+two:
+  text: MyText
+  question: two
+  correct: false

--- a/test/fixtures/categories.yml
+++ b/test/fixtures/categories.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  description: MyText
+
+two:
+  name: MyString
+  description: MyText

--- a/test/fixtures/questions.yml
+++ b/test/fixtures/questions.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  text: MyText
+  test: one
+
+two:
+  text: MyText
+  test: two

--- a/test/fixtures/tests.yml
+++ b/test/fixtures/tests.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  level: 1
+  time_limit: 1
+  category: one
+  user: one
+
+two:
+  name: MyString
+  level: 1
+  time_limit: 1
+  category: two
+  user: two

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  email: MyString
+  password_digest: MyString
+
+two:
+  name: MyString
+  email: MyString
+  password_digest: MyString

--- a/test/models/answer_test.rb
+++ b/test/models/answer_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class AnswerTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/category_test.rb
+++ b/test/models/category_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CategoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/question_test.rb
+++ b/test/models/question_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class QuestionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/test_test.rb
+++ b/test/models/test_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TestTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This commit adds Rails models for Test, Question, Answer, User, and Category entities, along with database-level integrity constraints to ensure required attributes cannot contain null values. Additionally, default values have been added using the migrations mechanism for the test level and the correct attribute of the Response.